### PR TITLE
fixed user profile screen to match figma

### DIFF
--- a/components/UserProfile/index.tsx
+++ b/components/UserProfile/index.tsx
@@ -1,6 +1,7 @@
 import { ScrollView, View, TouchableHighlight } from 'react-native';
 import React from 'react';
 import Icon from 'react-native-vector-icons/Entypo';
+import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 
 import { useNavigation, CompositeNavigationProp } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -13,6 +14,7 @@ import { RootState } from '../../redux/rootReducer';
 
 import { UserProfileScreenParamList } from '../../navigation/SharedStack/UserProfile/types';
 import { BottomTabParamList } from '../../navigation/MainNavBar/types';
+// import DonationScreenStack from '../../navigation/DonorStack/Donate/index';
 
 type ProfileScreenProp = CompositeNavigationProp<
     StackNavigationProp<UserProfileScreenParamList, 'UserProfileScreen'>,
@@ -26,7 +28,6 @@ type ProfileScreenProp = CompositeNavigationProp<
 export default function UserProfile() {
   const authState = useSelector((state: RootState) => state.auth);
   const navigation = useNavigation<ProfileScreenProp>();
-
   const fullAddress = authState.pickupAddresses.map((businessAddress) => `${businessAddress.buildingNumber} ${businessAddress.streetAddress} \n${businessAddress.city}, ${businessAddress.state} ${businessAddress.zipCode}`).join('\n\n') || 'No Address';
 
   return (
@@ -43,27 +44,60 @@ export default function UserProfile() {
           <Text style={styles.heading}>Personal Identification </Text>
           <EditButton onEdit={() => navigation.navigate('EditUserProfileScreen')} />
         </View>
-
+        <Text style={styles.body}>Company Name</Text>
+        <Text style={styles.description}>{authState.businessName || 'No Business Name'}</Text>
         <Text style={styles.body}>Phone Number</Text>
         <Text style={styles.description}>{authState.phoneNumber || 'No Phone Number'}</Text>
-        <Text style={styles.body}>Email</Text>
-        <Text style={styles.description}>{authState.email || 'No Email'}</Text>
-
+        {/* <Text style={styles.body}>Email</Text>
+        <Text style={styles.description}>{authState.email || 'No Email'}</Text> */}
+        <Text style={styles.body}>Role</Text>
+        <Text style={styles.description}>{authState.roles.length > 0 ? authState.roles : 'No role'} </Text>
         <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+          <Text style={styles.heading}>Address List</Text>
+
+        </View>
+        {/* <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
           <Text style={styles.heading}>Business Information</Text>
           <EditButton onEdit={() => navigation.navigate('EditUserProfileScreen')} />
         </View>
         <Text style={styles.body}>Name</Text>
-        <Text style={styles.description}>{authState.businessName || 'No Business Name'}</Text>
+        <Text style={styles.description}>{authState.businessName || 'No Business Name'}</Text> */}
         <Text style={styles.body}>Address{authState.pickupAddresses.length > 1 ? 'es' : ''}</Text>
-        <Text style={styles.description}>{fullAddress}</Text>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+          <Text style={styles.description}>{fullAddress}</Text>
+          <MoreButton onClick={() => console.log('More activity')} />
+        </View>
       </ScrollView>
     </View>
   );
 }
 
 /**
- * Structure for the edit button
+  * Structure for the edit button
+ * @param props onEdit function to be called when the edit button is pressed
+ * @returns {JSX.Element}
+ */
+
+function MoreButton(props: { onClick: () => void }) {
+  return (
+    <View>
+      <TouchableHighlight
+        onPress={props.onClick}
+        underlayColor="transparent"
+      >
+        <View style={{ flexGrow: 1, flexDirection: 'row', alignContent: 'center' }}>
+          <Text style={styles.moreButton}>
+            More
+          </Text>
+          <Icon name="chevron-thin-right" size={20} style={styles.moreIcon} />
+        </View>
+      </TouchableHighlight>
+    </View>
+  );
+}
+
+/**
+ * Structure for the edit button=
  * @param props onEdit function to be called when the edit button is pressed
  * @returns {JSX.Element}
  */
@@ -74,11 +108,11 @@ function EditButton(props: { onEdit: () => void }) {
         onPress={props.onEdit}
         underlayColor="transparent"
       >
-        <View style={{ flexGrow: 1, flexDirection: 'row', alignContent: 'center' }}>
-          <Text style={styles.button}>
+        <View style={{ flexGrow: 1, flexDirection: 'column', alignContent: 'center' }}>
+          <MaterialIcon name="edit" size={20} style={styles.icon} />
+          <Text style={styles.editButton}>
             Edit
           </Text>
-          <Icon name="chevron-thin-right" size={20} style={styles.icon} />
         </View>
       </TouchableHighlight>
     </View>

--- a/components/UserProfile/styles.tsx
+++ b/components/UserProfile/styles.tsx
@@ -45,9 +45,25 @@ const styles = StyleSheet.create({
     marginRight: 2,
     marginTop: 12
   },
+  editButton: {
+    fontSize: 14,
+    color: lightBlueColor,
+    marginRight: 2,
+    marginTop: 0
+  },
+  moreButton: {
+    fontSize: 14,
+    color: lightBlueColor,
+    marginRight: 2
+  },
   icon: {
     marginTop: 10,
+    marginLeft: 4,
     color: lightBlueColor,
+  },
+  moreIcon: {
+    marginLeft: 4,
+    color: lightBlueColor
   },
   info: {
     fontSize: 18,


### PR DESCRIPTION
## PR Title/Tagline

What does this PR change and why?

Changed the user profile screen to match the screen on figma. The more button was added but the button isn't implemented.

### How to Test

1. Please add or build upon a testing card to the [Notion page](http://notion.so) and link it here

### Important Changes

- Database change / migration to run
- Environment config change
- Breaking API change

### Related Github Issues

- #[Number of Issue]
- Or, remember to link to an issue on the sidebar

### Related PRs

- #PRNUMBER

### Checklist

- [ ]  Database schema docs have been updated or are not necessary
- [ ]  Code follows design and style guidelines
- [ ]  Code is commented with doc blocks
- [ ]  Tests have been written and executed or are not necessary
- [ ]  Latest code has been rebased from base branch (usually `develop`)
- [ ]  Commits follow guidelines (concise, squashed, etc)
- [ ]  Github issues have been linked in relevant commits
- [ ]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR
