### PR TITLE
Admin acceptance and address assignment

### DIFF
--- a/components/AddressForm/index.tsx
+++ b/components/AddressForm/index.tsx
@@ -13,11 +13,12 @@ import PrimaryButton from '../Button/PrimaryButton';
 type AddressFormProps = {
   ButtonTitle: string,
   UserAddress?: Address,
+  backButton?: boolean,
   goBack: () => void,
   onSubmit: (addressObj: Address | null) => void,
 }
 
-const AddressForm = ({ ButtonTitle, UserAddress, goBack, onSubmit }: AddressFormProps) => {
+const AddressForm = ({ ButtonTitle, UserAddress, backButton, goBack, onSubmit }: AddressFormProps) => {
   const [address, setAddress] = useState<string>(UserAddress ? UserAddress.streetAddress : '');
   const [city, setCity] = useState<string>(UserAddress ? UserAddress?.city : '');
   const [zipCode, onZipCodeChange] = useState<string>(UserAddress ? UserAddress.zipCode.toString : '');
@@ -43,7 +44,11 @@ const AddressForm = ({ ButtonTitle, UserAddress, goBack, onSubmit }: AddressForm
           keyboardShouldPersistTaps="handled"
         >
           <View style={{}} />
-          <HeaderBackButton tintColor="#F37B36" style={styles.backButton} onPress={() => goBack()} />
+          {
+            !backButton ? (
+              <HeaderBackButton tintColor="#F37B36" style={styles.backButton} onPress={() => goBack()} />
+            ) : null
+          }
           <View style={{}}>
             <View style={{}}>
               <View style={{}} />

--- a/components/AddressSelectionForm/index.tsx
+++ b/components/AddressSelectionForm/index.tsx
@@ -1,0 +1,149 @@
+import React, { useState } from 'react';
+import { StyleSheet, Alert, View, Modal, Text, Pressable, KeyboardAvoidingView, TouchableHighlight, ScrollView } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import Icon from 'react-native-vector-icons/Entypo';
+import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
+import { useSelector, useDispatch } from 'react-redux';
+import axios from 'axios';
+
+import styles from './styles';
+import { RootState } from '../../redux/rootReducer';
+import { Address, DonationForm } from '../../types';
+import { Header, ChevronButton, PrimaryButton, SecondaryButton } from '../../components';
+import { DonateTabParamList } from '../../navigation/DonorStack/Donate/types';
+import { setPickupAddresses } from '../../redux/reducers/authReducer';
+import { ThemeColor } from '../../constants/Colors';
+
+type AddressSelectionParams = {
+    title: string,
+    subtitle: string,
+    navigation: any,
+    buttonTitle: string,
+    handleSubmit: (address: Address) => void,
+    backButton ?: boolean
+    donationForm ?: DonationForm
+
+}
+
+const AddressFormScreen = ({
+  title,
+  subtitle,
+  navigation,
+  buttonTitle,
+  handleSubmit,
+  backButton,
+  donationForm
+
+}: AddressSelectionParams) => {
+  const authState = useSelector((state: RootState) => state.auth);
+  const dispatch = useDispatch();
+
+  const [selectedAddress, setSelectedAddress] = useState<Address | null>(authState.pickupAddresses.length === 1 ? authState.pickupAddresses[0] : null);
+  const dummyAddress: Address = {
+    streetAddress: 'North Ave NW',
+    buildingNumber: 0,
+    city: 'Atlanta',
+    state: 'GA',
+    zipCode: 30332,
+    longitude: 10,
+    latitude: 100,
+  };
+  const pickupAddresses = [dummyAddress, ...authState.pickupAddresses];
+
+  return (
+    <View style={styles.container}>
+      <ScrollView style={styles.scrollView}>
+        <View style={styles.contentContainer}>
+          {(backButton !== false) && <ChevronButton onPress={navigation.goBack} text="Donation Cart" />}
+          <Header title={title} showCartButton={false} />
+          <Text style={{ marginBottom: 20, marginTop: -10 }}>{subtitle}</Text>
+          <SecondaryButton onPress={() => navigation.navigate('EditAddressScreen')}>
+            <>
+              <Icon name="plus" size={15} />
+              Add address
+            </>
+          </SecondaryButton>
+          {/* <Text>{JSON.stringify(authState.pickupAddresses, null, 2)}</Text> */}
+          {pickupAddresses.map((address: Address) => (
+            <AddressCard
+              selected={selectedAddress?._id === address._id}
+              key={address._id}
+              address={address}
+              businessName={authState.businessName}
+              onPress={() => setSelectedAddress(address)}
+              onEdit={() => {
+                navigation.navigate('EditAddressScreen' as any, { address });
+              }}
+              onDelete={() => {
+                const url = `/api/user/pickupAddress/${authState._id}?addressId=${address._id}`;
+                Alert.alert('Are you sure you want to delete this pickup address?', '', [
+                  {
+                    text: 'Cancel',
+                    style: 'cancel',
+                  },
+                  {
+                    text: 'Delete',
+                    style: 'destructive',
+                    onPress: () => {
+                      axios.delete(url).then(() => {
+                        dispatch(setPickupAddresses(authState.pickupAddresses.filter((a: Address) => a._id !== address._id)));
+                      }).catch((e) => {
+                        Alert.alert('Error deleting pickup address.', e.message);
+                      });
+                    }
+                  }
+                ]);
+              }}
+            />
+          ))}
+          <PrimaryButton
+            onPress={() => {
+              if (selectedAddress) {
+                handleSubmit(selectedAddress);
+              }
+            }}
+            disabled={!selectedAddress}
+          >
+            {buttonTitle}
+          </PrimaryButton>
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+function AddressCard(props: { address: Address, businessName: string, onPress: () => void, onEdit: () => void, onDelete: () => void, selected?: boolean }) {
+  const fullAddress = `${props.address.streetAddress} \n${props.address.city}, ${props.address.state} ${props.address.zipCode}`;
+
+  return (
+    <TouchableHighlight onPress={props.onPress} underlayColor="transparent">
+      <View style={[styles.addressCard, (props.selected ? { borderColor: ThemeColor, borderWidth: 2, backgroundColor: 'rgba(243, 123, 54, 0.15)' } : {})]}>
+        <View style={{ flex: 2 }}>
+          <Text style={{ fontWeight: '700', fontSize: 15 }}>{props.businessName}</Text>
+          <Text style={{ marginTop: 5, fontSize: 12 }}>{fullAddress}</Text>
+        </View>
+        <View style={{ flex: 1, flexDirection: 'row', justifyContent: 'flex-end' }}>
+          <View style={{ flexDirection: 'column', justifyContent: 'center', marginRight: 15 }}>
+            <TouchableHighlight onPress={props.onEdit} underlayColor="transparent">
+              <>
+                <MaterialIcon name="edit" size={25} style={{ color: '#5D5D5D', alignSelf: 'center' }} />
+                <Text style={{ fontSize: 12, color: '#5D5D5D' }}>Edit</Text>
+              </>
+            </TouchableHighlight>
+          </View>
+          <View style={{ flexDirection: 'column', justifyContent: 'center' }}>
+            <TouchableHighlight onPress={props.onDelete} underlayColor="transparent">
+              <>
+                <MaterialIcon name="delete" size={25} style={{ color: '#5D5D5D', alignSelf: 'center' }} />
+                <Text style={{ fontSize: 12, color: '#5D5D5D' }}>Delete</Text>
+              </>
+            </TouchableHighlight>
+          </View>
+        </View>
+      </View>
+    </TouchableHighlight>
+  );
+}
+
+export default AddressFormScreen;

--- a/components/AddressSelectionForm/index.tsx
+++ b/components/AddressSelectionForm/index.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet, Alert, View, Modal, Text, Pressable, KeyboardAvoidingView, TouchableHighlight, ScrollView } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
+import { Alert, View, Text, Pressable, KeyboardAvoidingView, TouchableHighlight, ScrollView } from 'react-native';
 import Icon from 'react-native-vector-icons/Entypo';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import { useSelector, useDispatch } from 'react-redux';
@@ -10,10 +8,14 @@ import axios from 'axios';
 import styles from './styles';
 import { RootState } from '../../redux/rootReducer';
 import { Address, DonationForm } from '../../types';
-import { Header, ChevronButton, PrimaryButton, SecondaryButton } from '../../components';
-import { DonateTabParamList } from '../../navigation/DonorStack/Donate/types';
 import { setPickupAddresses } from '../../redux/reducers/authReducer';
 import { ThemeColor } from '../../constants/Colors';
+
+// Components
+import ChevronButton from '../ChevronButton';
+import Header from '../Header';
+import PrimaryButton from '../Button/PrimaryButton';
+import SecondaryButton from '../Button/SecondaryButton';
 
 type AddressSelectionParams = {
     title: string,
@@ -68,9 +70,9 @@ const AddressFormScreen = ({
           {pickupAddresses.map((address: Address) => (
             <AddressCard
               selected={selectedAddress?._id === address._id}
-              key={address._id}
+              key={address.longitude}
               address={address}
-              businessName={authState.businessName}
+              businessName="Test Business Name"
               onPress={() => setSelectedAddress(address)}
               onEdit={() => {
                 navigation.navigate('EditAddressScreen' as any, { address });

--- a/components/AddressSelectionForm/styles.tsx
+++ b/components/AddressSelectionForm/styles.tsx
@@ -1,0 +1,30 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  scrollView: {
+    marginHorizontal: 0,
+    width: '100%',
+  },
+  contentContainer: {
+    width: '85%',
+    marginHorizontal: '7.5%',
+    marginTop: '10%',
+  },
+  addressCard: {
+    borderWidth: 1,
+    borderColor: '#b8b8b8',
+    padding: 15,
+    borderRadius: 5,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 15
+  }
+});
+
+export default styles;

--- a/components/AddressSelectionForm/styles.tsx
+++ b/components/AddressSelectionForm/styles.tsx
@@ -2,19 +2,20 @@ import { StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     backgroundColor: '#fff',
+    flex: 1,
     justifyContent: 'center',
-    alignItems: 'center'
+    alignItems: 'center',
   },
   scrollView: {
+    backgroundColor: 'white',
     marginHorizontal: 0,
     width: '100%',
   },
   contentContainer: {
+    backgroundColor: 'white',
     width: '85%',
     marginHorizontal: '7.5%',
-    marginTop: '10%',
   },
   addressCard: {
     borderWidth: 1,

--- a/components/GeneralModal/index.tsx
+++ b/components/GeneralModal/index.tsx
@@ -81,12 +81,12 @@ const GeneralModal = ({
 
   if (numButtons === 1) {
     modalHeight = '60%';
-    flexTitle = 1;
+    flexTitle = 2;
     flexSubtitle = 3;
     flexButton = 4;
   } else {
     modalHeight = '80%';
-    flexTitle = 1;
+    flexTitle = 2;
     flexSubtitle = 3;
     flexButton = 7;
   }

--- a/components/index.ts
+++ b/components/index.ts
@@ -12,3 +12,4 @@ export { default as DonationListBox } from './DonationsListBox';
 export { default as PrimaryButton } from './Button/PrimaryButton';
 export { default as SecondaryButton } from './Button/SecondaryButton';
 export { default as DonationQueueRow } from './DonationQueueRow';
+export { default as AddressSelection } from './AddressSelectionForm';

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "react-native-vector-icons": "^8.1.0",
         "react-native-web": "0.17.1",
         "react-redux": "^7.2.2",
+        "react-test-renderer": "^17.0.1",
         "redux": "^4.0.5",
         "redux-persist": "^6.0.0",
         "safe-compare": "^1.1.4"
@@ -14822,7 +14823,6 @@
       "version": "16.14.1",
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
       "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
-      "dev": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0"
@@ -14830,6 +14830,25 @@
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0"
       }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-/dRae3mj6aObwkjCcxZPlxDFh73XZLgvwhhyON2haZGUEhiaY5EjfAdw+d/rQmlcFwdTpMXCSGVk374QbCTlrA==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.1",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.1"
+      },
+      "peerDependencies": {
+        "react": "17.0.1"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/readable-stream": {
       "version": "2.3.7",
@@ -19866,6 +19885,7 @@
           "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.64.0.tgz",
           "integrity": "sha512-K1sHO3ODBFCr7uEiCQ4RvVr+cQg0EHQF8ChVPnecGh/WDD8udrTq9ECwB0dRfMjAvlsHtRUlJm6ZSI8UPgum2w==",
           "requires": {
+            "@babel/core": "^7.0.0",
             "babel-preset-fbjs": "^3.3.0",
             "metro-babel-transformer": "0.64.0",
             "metro-react-native-babel-preset": "0.64.0",
@@ -27080,6 +27100,7 @@
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.64.0.tgz",
       "integrity": "sha512-HcZ0RWQRuJfpPiaHyFQJzcym+/dDIVUPwUAXWoub/C4GkGu+mPjp8vqK6g0FxokCnnI2TK0gZTza2IDfiNNscQ==",
       "requires": {
+        "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -27125,6 +27146,7 @@
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.59.0.tgz",
       "integrity": "sha512-1O3wrnMq4NcPQ1asEcl9lRDn/t+F1Oef6S9WaYVIKEhg9m/EQRGVrrTVP+R6B5Eeaj3+zNKbzM8Dx/NWy1hUbQ==",
       "requires": {
+        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.59.0",
         "metro-react-native-babel-preset": "0.59.0",
@@ -28274,6 +28296,7 @@
           "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.64.0.tgz",
           "integrity": "sha512-K1sHO3ODBFCr7uEiCQ4RvVr+cQg0EHQF8ChVPnecGh/WDD8udrTq9ECwB0dRfMjAvlsHtRUlJm6ZSI8UPgum2w==",
           "requires": {
+            "@babel/core": "^7.0.0",
             "babel-preset-fbjs": "^3.3.0",
             "metro-babel-transformer": "0.64.0",
             "metro-react-native-babel-preset": "0.64.0",
@@ -28614,10 +28637,27 @@
       "version": "16.14.1",
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
       "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
-      "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0"
+      }
+    },
+    "react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-/dRae3mj6aObwkjCcxZPlxDFh73XZLgvwhhyON2haZGUEhiaY5EjfAdw+d/rQmlcFwdTpMXCSGVk374QbCTlrA==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.1",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        }
       }
     },
     "readable-stream": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-native-vector-icons": "^8.1.0",
     "react-native-web": "0.17.1",
     "react-redux": "^7.2.2",
+    "react-test-renderer": "^17.0.1",
     "redux": "^4.0.5",
     "redux-persist": "^6.0.0",
     "safe-compare": "^1.1.4"

--- a/redux/reducers/donationQueue/index.ts
+++ b/redux/reducers/donationQueue/index.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { DonationForm } from '../../../types';
+import { DonationForm, Address } from '../../../types';
 import { DonationQueue } from './types';
 
 const initialState = {
@@ -17,14 +17,16 @@ const donationQueueReducer = createSlice({
     searchDonations(state, action: PayloadAction<DonationForm[]>) {
       state.donationSearch = action.payload;
     },
-    updateStatus(state, action: PayloadAction<{donationForm:DonationForm, status: string}>) {
-      console.log(state);
-      console.log(action);
+    updateStatus(state, action: PayloadAction<{donationForm:DonationForm, status: string, dropoffAddr?: Address}>) {
       const donation = state.donationQueue.filter((f: any) => f._id === action.payload.donationForm._id)[0];
       const list = state.donationQueue;
       for (let index = 0; index < list.length; index += 1) {
         if (list[index]._id === donation._id) {
           list[index].status = action.payload.status;
+          console.log(action.payload.dropoffAddr);
+          if (action.payload.dropoffAddr) {
+            list[index].dropOffAddress = action.payload.dropoffAddr;
+          }
         }
       }
       state.donationQueue = list;

--- a/redux/reducers/donationQueue/index.ts
+++ b/redux/reducers/donationQueue/index.ts
@@ -16,9 +16,21 @@ const donationQueueReducer = createSlice({
     },
     searchDonations(state, action: PayloadAction<DonationForm[]>) {
       state.donationSearch = action.payload;
-    }
+    },
+    updateStatus(state, action: PayloadAction<{donationForm:DonationForm, status: string}>) {
+      console.log(state);
+      console.log(action);
+      const donation = state.donationQueue.filter((f: any) => f._id === action.payload.donationForm._id)[0];
+      const list = state.donationQueue;
+      for (let index = 0; index < list.length; index += 1) {
+        if (list[index]._id === donation._id) {
+          list[index].status = action.payload.status;
+        }
+      }
+      state.donationQueue = list;
+    },
   }
 });
 
-export const { loadDonations, searchDonations } = donationQueueReducer.actions;
+export const { loadDonations, searchDonations, updateStatus } = donationQueueReducer.actions;
 export default donationQueueReducer.reducer;

--- a/screens/DonationForm/AddressScreen/index.tsx
+++ b/screens/DonationForm/AddressScreen/index.tsx
@@ -10,7 +10,7 @@ import axios from 'axios';
 import styles from './styles';
 import { RootState } from '../../../redux/rootReducer';
 import { Address } from '../../../types';
-import { Header, ChevronButton, PrimaryButton, SecondaryButton } from '../../../components';
+import { Header, ChevronButton, PrimaryButton, SecondaryButton, AddressSelection } from '../../../components';
 import { DonateTabParamList } from '../../../navigation/DonorStack/Donate/types';
 import { setPickupAddresses } from '../../../redux/reducers/authReducer';
 import { setAddress } from '../../../redux/reducers/donationCartReducer';
@@ -35,92 +35,10 @@ const DonateFormAddressScreen = () => {
   return (
     <View style={styles.container}>
       <ScrollView style={styles.scrollView}>
-        <View style={styles.contentContainer}>
-          <ChevronButton onPress={navigation.goBack} text="Donation Cart" />
-          <Header title="Your address" showCartButton={false} />
-          <Text style={{ marginBottom: 20, marginTop: -10 }}>Select the address you would like the donation to be picked up at.</Text>
-          <SecondaryButton onPress={() => navigation.navigate('EditAddressScreen')}>
-            <>
-              <Icon name="plus" size={15} />
-              Add address
-            </>
-          </SecondaryButton>
-          {/* <Text>{JSON.stringify(authState.pickupAddresses, null, 2)}</Text> */}
-          {authState.pickupAddresses.map((address: Address) => (
-            <AddressCard
-              selected={selectedAddress?._id === address._id}
-              key={address._id}
-              address={address}
-              businessName={authState.businessName}
-              onPress={() => setSelectedAddress(address)}
-              onEdit={() => {
-                navigation.navigate('EditAddressScreen' as any, { address });
-              }}
-              onDelete={() => {
-                const url = `/api/user/pickupAddress/${authState._id}?addressId=${address._id}`;
-                Alert.alert('Are you sure you want to delete this pickup address?', '', [
-                  {
-                    text: 'Cancel',
-                    style: 'cancel',
-                  },
-                  {
-                    text: 'Delete',
-                    style: 'destructive',
-                    onPress: () => {
-                      axios.delete(url).then(() => {
-                        dispatch(setPickupAddresses(authState.pickupAddresses.filter((a: Address) => a._id !== address._id)));
-                      }).catch((e) => {
-                        Alert.alert('Error deleting pickup address.', e.message);
-                      });
-                    }
-                  }
-                ]);
-              }}
-            />
-          ))}
-          <PrimaryButton
-            onPress={handleSubmit}
-            disabled={!selectedAddress}
-          >
-            Schedule pickup time
-          </PrimaryButton>
-        </View>
+        <AddressSelection title="Your Address" subtitle="Select the address you would like the donation to be picked up at." navigation={navigation} buttonTitle="Schedule pickup time" handleSubmit={handleSubmit} />
       </ScrollView>
     </View>
   );
 };
-
-function AddressCard(props: { address: Address, businessName: string, onPress: () => void, onEdit: () => void, onDelete: () => void, selected?: boolean }) {
-  const fullAddress = `${props.address.streetAddress} \n${props.address.city}, ${props.address.state} ${props.address.zipCode}`;
-
-  return (
-    <TouchableHighlight onPress={props.onPress} underlayColor="transparent">
-      <View style={[styles.addressCard, (props.selected ? { borderColor: ThemeColor, borderWidth: 2, backgroundColor: 'rgba(243, 123, 54, 0.15)' } : {})]}>
-        <View style={{ flex: 2 }}>
-          <Text style={{ fontWeight: '700', fontSize: 15 }}>{props.businessName}</Text>
-          <Text style={{ marginTop: 5, fontSize: 12 }}>{fullAddress}</Text>
-        </View>
-        <View style={{ flex: 1, flexDirection: 'row', justifyContent: 'flex-end' }}>
-          <View style={{ flexDirection: 'column', justifyContent: 'center', marginRight: 15 }}>
-            <TouchableHighlight onPress={props.onEdit} underlayColor="transparent">
-              <>
-                <MaterialIcon name="edit" size={25} style={{ color: '#5D5D5D', alignSelf: 'center' }} />
-                <Text style={{ fontSize: 12, color: '#5D5D5D' }}>Edit</Text>
-              </>
-            </TouchableHighlight>
-          </View>
-          <View style={{ flexDirection: 'column', justifyContent: 'center' }}>
-            <TouchableHighlight onPress={props.onDelete} underlayColor="transparent">
-              <>
-                <MaterialIcon name="delete" size={25} style={{ color: '#5D5D5D', alignSelf: 'center' }} />
-                <Text style={{ fontSize: 12, color: '#5D5D5D' }}>Delete</Text>
-              </>
-            </TouchableHighlight>
-          </View>
-        </View>
-      </View>
-    </TouchableHighlight>
-  );
-}
 
 export default DonateFormAddressScreen;

--- a/templates/NavTypes.ts
+++ b/templates/NavTypes.ts
@@ -3,4 +3,6 @@ import { DonationForm } from '../types';
 export type TemplateNavParamList = {
   DonationQueue: undefined,
   DetailDonationOnQueue: DonationForm, // this will need to change so that it doesn't take in undefined params
+  AddressScreen: DonationForm,
+  EditAddressScreen: undefined,
 };

--- a/templates/index.tsx
+++ b/templates/index.tsx
@@ -2,6 +2,8 @@ import { createStackNavigator } from '@react-navigation/stack';
 import * as React from 'react';
 import DonationQueue from './screens/ScreenTemplate/DonationQueue';
 import DetailDonationOnQueue from './screens/DetailDonationOnQueue';
+import AddressScreen from './screens/AddressScreen/index';
+import EditAddressScreen from './screens/EditAddressScreen/index';
 
 import { TemplateNavParamList } from './NavTypes';
 
@@ -19,6 +21,16 @@ export default function TestStack() {
       <TestingStack.Screen
         name="DetailDonationOnQueue"
         component={DetailDonationOnQueue}
+        options={{ headerTitle: '', headerShown: true, headerTintColor: '#F37B36' }}
+      />
+      <TestingStack.Screen
+        name="AddressScreen"
+        component={AddressScreen}
+        options={{ headerTitle: '', headerShown: true, headerTintColor: '#F37B36' }}
+      />
+      <TestingStack.Screen
+        name="EditAddressScreen"
+        component={EditAddressScreen}
         options={{ headerTitle: '', headerShown: true, headerTintColor: '#F37B36' }}
       />
     </TestingStack.Navigator>

--- a/templates/screens/AddressScreen/index.tsx
+++ b/templates/screens/AddressScreen/index.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { View, Text, ScrollView, TouchableHighlight, Alert } from 'react-native';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import Icon from 'react-native-vector-icons/Entypo';
+import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
+import { useSelector, useDispatch } from 'react-redux';
+import axios from 'axios';
+
+import styles from './styles';
+import { RootState } from '../../../redux/rootReducer';
+import { Address, DonationForm } from '../../../types';
+import { Header, ChevronButton, PrimaryButton, SecondaryButton, AddressSelection } from '../../../components';
+import { setLoading } from '../../../redux/reducers/loadingReducer';
+import donationQueue, { updateStatus } from '../../../redux/reducers/donationQueue';
+import { ThemeColor } from '../../../constants/Colors';
+import { TemplateNavParamList } from '../../NavTypes';
+import LoadingScreen from '../../../screens/LoadingScreen';
+
+type ParamList = {
+  AddressDropoffScreen: {
+    donationForm: DonationForm,
+    navigation: any,
+  }
+}
+
+type AdminScreenProp = StackNavigationProp<TemplateNavParamList>;
+
+function AdminAcceptAddressScreen() {
+  const route = useRoute<RouteProp<ParamList, 'AddressDropoffScreen'>>();
+  const state = useSelector((state: RootState) => state);
+  const navigation = useNavigation<AdminScreenProp>();
+  const dispatch = useDispatch();
+
+  const loadingState = useSelector((state: RootState) => state.loading.loadingStatus);
+
+  // destructure route.params
+  const { donationForm } = route.params;
+
+  const setAddress = (address: Address) => {
+    if (donationForm) {
+      dispatch(setLoading({ loading: true }));
+      const formdata = new FormData();
+      formdata.append('json', JSON.stringify({
+        dropOffAddress: address,
+        status: 'Unclaim'
+      }));
+      axios.put('/api/ongoingdonations/62185e29d8b2650022fadd1a', formdata)
+        .then((res) => {
+          dispatch(updateStatus({ donationForm, status: 'Unclaim' }));
+          const donation = state.donationQueueReducer.donationQueue.find((donation) => donation._id === donationForm._id);
+          if (donation) {
+            console.log(donation);
+            navigation.navigate('DetailDonationOnQueue', donation);
+          }
+        })
+        .catch((err) => {
+          Alert.alert('Error accepting this donation.', err.message);
+        })
+        .finally(() => {
+          dispatch(setLoading({ loading: false }));
+        });
+    }
+  };
+
+  return (
+    loadingState ? (
+      <LoadingScreen />
+    ) : (
+      <View style={styles.container}>
+        <ScrollView style={styles.scrollView}>
+          <AddressSelection title="Destination Address" subtitle="Select a destination address for this donation below, or add a new address." navigation={navigation} buttonTitle="Accept Donation" handleSubmit={setAddress} backButton={false} />
+        </ScrollView>
+      </View>
+    )
+  );
+}
+
+export default AdminAcceptAddressScreen;

--- a/templates/screens/AddressScreen/index.tsx
+++ b/templates/screens/AddressScreen/index.tsx
@@ -18,16 +18,15 @@ import { TemplateNavParamList } from '../../NavTypes';
 import LoadingScreen from '../../../screens/LoadingScreen';
 
 type ParamList = {
-  AddressDropoffScreen: {
+  AddressScreen: {
     donationForm: DonationForm,
-    navigation: any,
   }
 }
 
 type AdminScreenProp = StackNavigationProp<TemplateNavParamList>;
 
 function AdminAcceptAddressScreen() {
-  const route = useRoute<RouteProp<ParamList, 'AddressDropoffScreen'>>();
+  const route = useRoute<RouteProp<ParamList, 'AddressScreen'>>();
   const state = useSelector((state: RootState) => state);
   const navigation = useNavigation<AdminScreenProp>();
   const dispatch = useDispatch();
@@ -35,9 +34,9 @@ function AdminAcceptAddressScreen() {
   const loadingState = useSelector((state: RootState) => state.loading.loadingStatus);
 
   // destructure route.params
-  const { donationForm } = route.params;
 
   const setAddress = (address: Address) => {
+    const { donationForm } = route.params;
     if (donationForm) {
       dispatch(setLoading({ loading: true }));
       const formdata = new FormData();
@@ -48,11 +47,7 @@ function AdminAcceptAddressScreen() {
       axios.put('/api/ongoingdonations/62185e29d8b2650022fadd1a', formdata)
         .then((res) => {
           dispatch(updateStatus({ donationForm, status: 'Unclaim' }));
-          const donation = state.donationQueueReducer.donationQueue.find((donation) => donation._id === donationForm._id);
-          if (donation) {
-            console.log(donation);
-            navigation.navigate('DetailDonationOnQueue', donation);
-          }
+          navigation.navigate('DonationQueue');
         })
         .catch((err) => {
           Alert.alert('Error accepting this donation.', err.message);

--- a/templates/screens/AddressScreen/index.tsx
+++ b/templates/screens/AddressScreen/index.tsx
@@ -27,7 +27,6 @@ type AdminScreenProp = StackNavigationProp<TemplateNavParamList>;
 
 function AdminAcceptAddressScreen() {
   const route = useRoute<RouteProp<ParamList, 'AddressScreen'>>();
-  const state = useSelector((state: RootState) => state);
   const navigation = useNavigation<AdminScreenProp>();
   const dispatch = useDispatch();
 
@@ -44,9 +43,9 @@ function AdminAcceptAddressScreen() {
         dropOffAddress: address,
         status: 'Unclaim'
       }));
-      axios.put('/api/ongoingdonations/62185e29d8b2650022fadd1a', formdata)
+      axios.put(`/api/ongoingdonations/${donationForm._id}`, formdata)
         .then((res) => {
-          dispatch(updateStatus({ donationForm, status: 'Unclaim' }));
+          dispatch(updateStatus({ donationForm, status: 'Unclaim', dropoffAddr: address }));
           navigation.navigate('DonationQueue');
         })
         .catch((err) => {
@@ -62,11 +61,9 @@ function AdminAcceptAddressScreen() {
     loadingState ? (
       <LoadingScreen />
     ) : (
-      <View style={styles.container}>
-        <ScrollView style={styles.scrollView}>
-          <AddressSelection title="Destination Address" subtitle="Select a destination address for this donation below, or add a new address." navigation={navigation} buttonTitle="Accept Donation" handleSubmit={setAddress} backButton={false} />
-        </ScrollView>
-      </View>
+      <ScrollView style={styles.scrollView}>
+        <AddressSelection title="Destination Address" subtitle="Select a destination address for this donation below, or add a new address." navigation={navigation} buttonTitle="Accept Donation" handleSubmit={setAddress} backButton={false} />
+      </ScrollView>
     )
   );
 }

--- a/templates/screens/AddressScreen/styles.tsx
+++ b/templates/screens/AddressScreen/styles.tsx
@@ -1,0 +1,30 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  scrollView: {
+    marginHorizontal: 0,
+    width: '100%',
+  },
+  contentContainer: {
+    width: '85%',
+    marginHorizontal: '7.5%',
+    marginTop: '10%',
+  },
+  addressCard: {
+    borderWidth: 1,
+    borderColor: '#b8b8b8',
+    padding: 15,
+    borderRadius: 5,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 15
+  }
+});
+
+export default styles;

--- a/templates/screens/AddressScreen/styles.tsx
+++ b/templates/screens/AddressScreen/styles.tsx
@@ -14,7 +14,6 @@ const styles = StyleSheet.create({
   contentContainer: {
     width: '85%',
     marginHorizontal: '7.5%',
-    marginTop: '10%',
   },
   addressCard: {
     borderWidth: 1,

--- a/templates/screens/DetailDonationOnQueue/index.tsx
+++ b/templates/screens/DetailDonationOnQueue/index.tsx
@@ -9,6 +9,7 @@ import styles from '../DetailDonationOnQueue/styles';
 import { Address, Donation, DonationForm } from '../../../types';
 import { RootState } from '../../../redux/rootReducer';
 import { setLoading } from '../../../redux/reducers/loadingReducer';
+import { updateStatus } from '../../../redux/reducers/donationQueue';
 import GeneralModal from '../../../components/GeneralModal';
 
 import { DonateTabParamList } from '../../../navigation/DonorStack/Donate/types';
@@ -74,7 +75,6 @@ function DetailDonationOnQueue() {
   const [denyModalVisible, setDenyModalVisible] = React.useState<boolean>(false);
   const closeDenyModal = () => setDenyModalVisible(false);
   const handleModalSubmit = (denyPressed: boolean, cancelPressed: boolean) => {
-    // setDenyModalVisible(false);
     if (denyPressed) {
       dispatch(setLoading({ loading: true }));
       const formdata = new FormData();
@@ -85,6 +85,7 @@ function DetailDonationOnQueue() {
       axios.put('/api/ongoingdonations/62185e29d8b2650022fadd1a', formdata)
         .then((res) => {
           console.log(res);
+          dispatch(updateStatus({ donationForm, status: 'Denied' }));
           navigation.goBack();
         })
         .catch((err) => {
@@ -148,8 +149,8 @@ function DetailDonationOnQueue() {
                 backgroundColor: '#11B25B'
               }}
               onPress={() => {
-                const donationObject = state.donationQueueReducer.donationQueue.find((donation) => donation._id === donationForm._id);
-                navigation.navigate('AddressScreen', donationObject as DonationForm);
+                // const donationObject = state.donationQueueReducer.donationQueue.find((donation) => donation._id === donationForm._id);
+                navigation.navigate('AddressScreen', { donationForm });
               }}
             >
               <Text style={{ fontSize: 17, color: '#FFFFFF', fontWeight: 'bold' }}>Accept</Text>

--- a/templates/screens/EditAddressScreen/index.tsx
+++ b/templates/screens/EditAddressScreen/index.tsx
@@ -5,7 +5,6 @@ import axios, { AxiosResponse } from 'axios';
 import { useSelector, useDispatch, batch } from 'react-redux';
 
 import { AddressForm } from '../../../components';
-import { DonateTabParamList } from '../../../navigation/DonorStack/Donate/types';
 import { Address } from '../../../types';
 import { RootState } from '../../../redux/rootReducer';
 import { setPickupAddresses } from '../../../redux/reducers/authReducer';
@@ -58,6 +57,7 @@ export default function EditAddresScreen({ route }: { route: { params: { address
         }
       }}
       ButtonTitle="Save address"
+      backButton
     />
   );
 }

--- a/templates/screens/EditAddressScreen/index.tsx
+++ b/templates/screens/EditAddressScreen/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import axios, { AxiosResponse } from 'axios';
+import { useSelector, useDispatch, batch } from 'react-redux';
+
+import { AddressForm } from '../../../components';
+import { DonateTabParamList } from '../../../navigation/DonorStack/Donate/types';
+import { Address } from '../../../types';
+import { RootState } from '../../../redux/rootReducer';
+import { setPickupAddresses } from '../../../redux/reducers/authReducer';
+import { setLoading } from '../../../redux/reducers/loadingReducer';
+import { TemplateNavParamList } from '../../NavTypes';
+
+type AdminScreenProp = StackNavigationProp<TemplateNavParamList>;
+
+export default function EditAddresScreen({ route }: { route: { params: { address: Address | undefined } } }) {
+  const authState = useSelector((state: RootState) => state.auth);
+  const navigation = useNavigation<AdminScreenProp>();
+  const dispatch = useDispatch();
+
+  const oldAddress = route?.params?.address ?? null;
+
+  const onSuccess = (response: AxiosResponse) => {
+    const newPickupAddresses = response.data.pickupAddresses as Address[];
+    // set authState pickup addresses to response
+    batch(() => {
+      dispatch(setPickupAddresses(newPickupAddresses));
+      dispatch(setLoading({
+        loading: false,
+      }));
+    });
+
+    navigation.goBack();
+  };
+
+  const onError = () => {
+    alert('This address could not be saved. Please try again later');
+    dispatch(setLoading({ loading: false }));
+  };
+
+  return (
+    <AddressForm
+      goBack={navigation.goBack}
+      onSubmit={(address) => {
+        if (address) {
+          // dispatch(setLoading({ loading: true }));
+          if (oldAddress) {
+            axios.put(`api/user/pickupAddress/${authState._id}`, {
+              _id: oldAddress._id, // preserve id
+              ...address
+            }).then(onSuccess).catch(onError);
+          } else {
+            axios.post(`/api/user/pickupAddress/${authState._id}`, address)
+              .then(onSuccess)
+              .catch(onError);
+          }
+        }
+      }}
+      ButtonTitle="Save address"
+    />
+  );
+}

--- a/templates/screens/ScreenTemplate/DonationQueue.tsx
+++ b/templates/screens/ScreenTemplate/DonationQueue.tsx
@@ -62,15 +62,6 @@ const DonationListScreen = () => {
   // const [filterDate, setFilterDate] = React.useState(new Date());
   const [overdueView, setOverdueView] = React.useState(false);
 
-  // dropOffAddress: {
-  //   streetAddress:"Hemphill Ave NW",
-  //   buildingNumber:900,
-  //   city:"Atlanta",
-  //   state:"GA",
-  //   zipCode:30332,
-  //   longitude:33.7799102,
-  //   latitude: -84.4053848
-  // },
   // gets ongoing donations
   useEffect(() => {
     // USE THIS AS REFERENCE ONLY


### PR DESCRIPTION
## Admin acceptance and address assignment

Adds functionality to the donation detail screen for pending donations. Admins can now accept or deny donations. When accepting, they must choose a delivery address to assign to the donation. 

### How to Test

1. You can work through the flow of accepting or denying the donations that are currently in the API. To test multiple times, change the status in MongoDB.

### Important Changes
- The accepting flow does not quite match what is in the Figma. Instead of going back to the DetailDonationOnQueue screen after accepting, it goes back to the main DonationQueue screen. This is due to the fact that the DetailDonationOnQueue screen would not rerender when the state changed. 

### Related Github Issues

- #161 

### Checklist

- [x]  Database schema docs have been updated or are not necessary
- [x]  Code follows design and style guidelines
- [x]  Code is commented with doc blocks
- [x]  Tests have been written and executed or are not necessary
- [x]  Latest code has been rebased from base branch (usually `develop`)
- [x]  Commits follow guidelines (concise, squashed, etc)
- [x]  Github issues have been linked in relevant commits
- [x]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR
